### PR TITLE
[0.0.2] Upgrade Flutter to 3.27.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@
 .classpath
 .project
 .settings/
-.vscode/*
+.vscode/
 
 # Flutter repo-specific
 /bin/cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Moved `shapeBorder` from `DropDown` class to `DropDownOptions` as `border`. Changed default to a rounded border of `24.0` instead of `15.0`.
 * Added new constructors and static helper methods to `SelectedListItem` class.
 * Added option to autofocus `SearchTextField`.
+* Upgraded minimum Flutter SDK to 3.27.0.
 
 ## 0.0.1
 

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -20,7 +20,7 @@
 .classpath
 .project
 .settings/
-.vscode/*
+.vscode/
 
 # Flutter repo-specific
 /bin/cache/

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -20,7 +20,7 @@ version: 1.0.0+1
 
 environment:
   sdk: ">=3.2.0 <4.0.0"
-  flutter: '>=3.16.0' # Build using this version
+  flutter: '>=3.27.0' # Build using this version
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -52,7 +52,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^3.0.0
+  flutter_lints: ^5.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ version: 0.0.1
 
 environment:
   sdk: ">=3.2.0 <4.0.0"
-  flutter: '>=3.16.0' # Build using this version
+  flutter: '>=3.27.0' # Build using this version
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
Upgrades the minimum Flutter SDK version to 3.27.0 in both the main and example project's pubspec.yaml files.

This ensures the project is using the latest stable version of the Flutter SDK.