### PR TITLE
[0.0.2] Patch Color.toARGB32()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Removed the default values for `searchFillColor` and `searchCursorColor` (now defaults to `null`).
 * Added style option `listSeparatorColor` to customize the default color of the list separator divider, which has been changed from `Colors.black12` to `Colors.transparent`.
-* Added contextual color models `BrightnessColor` and `ThemedColor` to allow for contextually aware colors ([see more](README#custom-color-models)).
+* Added contextual color models `BrightnessColor` and `ThemedColor` to allow for contextually aware colors ([see more](README.md#custom-color-models)).
 * Allow for all options to utilize new contextual color models.
 * Changed `listSeparatorColor` default from `Colors.transparent` to `BrightnessColor.bwa(alpha: 0.08)` and changed `SearchTextField` icon colors to be dependant on the brightness.
 * Added documentation for the `BrightnessColor` and `ThemedColor` models.

--- a/lib/model/contextual_colors.dart
+++ b/lib/model/contextual_colors.dart
@@ -193,6 +193,19 @@ class ThemedColor extends Color with ContextualThemed<Color?> {
       : super(resolver(ThemeData.fallback())?.toARGB32() ?? fallback);
 }
 
+extension ColorToArgb32 on Color {
+  int toARGB32() {
+    return _floatToInt8(a) << 24 |
+        _floatToInt8(r) << 16 |
+        _floatToInt8(g) << 8 |
+        _floatToInt8(b) << 0;
+  }
+
+  static int _floatToInt8(double x) {
+    return (x * 255.0).round() & 0xff;
+  }
+}
+
 class ContextualColor extends Color
     with ContextualPropertyWithResolver<Color?> {
   @override

--- a/lib/src/drop_down.dart
+++ b/lib/src/drop_down.dart
@@ -487,9 +487,9 @@ class DropDown<T> {
 
   /// Show the drop down modal.
   void show(BuildContext context) {
-    DropDownOptions<T> modalOptions = options ?? DropDownOptions<T>();
+    final DropDownOptions<T> modalOptions = options ?? DropDownOptions<T>();
 
-    List<SelectedListItem<T>> modalData =
+    final List<SelectedListItem<T>> modalData =
         data ?? unbuiltData?.asSelectedListItems() ?? [];
 
     showModalBottomSheet(


### PR DESCRIPTION
- Adds an extension to convert a Color to a 32-bit ARGB integer. This is a patch in order to support Flutter SDK 3.27.3. Color.toARGB32 gets added in Flutter SDK 3.29